### PR TITLE
Preserve provider-specific API keys in runtime env overlay

### DIFF
--- a/internal/config/runtime_env.go
+++ b/internal/config/runtime_env.go
@@ -34,8 +34,12 @@ func runtimeEnvValues(cfg RuntimeConfig) map[string]string {
 		values[key] = value
 	}
 
-	set("OPENAI_API_KEY", cfg.APIKey)
-	set("OPENROUTER_API_KEY", cfg.APIKey)
+	switch strings.ToLower(cfg.LLMProvider) {
+	case "openai":
+		set("OPENAI_API_KEY", cfg.APIKey)
+	case "openrouter", "deepseek":
+		set("OPENROUTER_API_KEY", cfg.APIKey)
+	}
 
 	set("LLM_PROVIDER", cfg.LLMProvider)
 	set("ALEX_LLM_PROVIDER", cfg.LLMProvider)


### PR DESCRIPTION
## Summary
- scope runtime environment API key injection to the selected LLM provider so other provider keys fall back to their original values
- extend runtime environment lookup tests to cover provider-specific overlays and base fallbacks

## Testing
- go test ./internal/config

------
https://chatgpt.com/codex/tasks/task_e_68e66d17aaf4833093238c0f3f239998