### PR TITLE
Fix env loader API key precedence

### DIFF
--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -225,3 +225,33 @@ func TestInvalidVerboseReturnsError(t *testing.T) {
 		t.Fatalf("expected error mentioning ALEX_VERBOSE, got %v", err)
 	}
 }
+
+func TestEnvAPIKeyRespectsProvider(t *testing.T) {
+	cfg, _, err := Load(
+		WithEnv(envMap{
+			"LLM_PROVIDER":       "openai",
+			"OPENAI_API_KEY":     "env-openai",
+			"OPENROUTER_API_KEY": "env-openrouter",
+		}.Lookup),
+	)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.APIKey != "env-openai" {
+		t.Fatalf("expected OPENAI_API_KEY to win, got %q", cfg.APIKey)
+	}
+
+	cfg, _, err = Load(
+		WithEnv(envMap{
+			"LLM_PROVIDER":       "openrouter",
+			"OPENAI_API_KEY":     "env-openai",
+			"OPENROUTER_API_KEY": "env-openrouter",
+		}.Lookup),
+	)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.APIKey != "env-openrouter" {
+		t.Fatalf("expected OPENROUTER_API_KEY to win, got %q", cfg.APIKey)
+	}
+}


### PR DESCRIPTION
## Summary
- prevent the environment loader from overriding the configured API key with a mismatched provider key
- add regression tests covering provider-specific API key precedence

## Testing
- go test ./internal/config

------
https://chatgpt.com/codex/tasks/task_e_68e67363d7348330923d73a9e03febb3